### PR TITLE
Update dependencies to fhir 0.12.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,9 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # fhir: ^0.11.0
-  fhir_r4:
-    path: ../../fhir_r4
+  fhir: ^0.12.0
   fhir_path:
     path: ../../fhir_path
   google_fonts: ^4.0.4

--- a/lib/lexer/literal_lexer.dart
+++ b/lib/lexer/literal_lexer.dart
@@ -4,7 +4,7 @@
 import 'dart:convert';
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:petitparser/petitparser.dart';
 import 'package:ucum/ucum.dart';
 

--- a/lib/parser/function_parser/conversions_parser.dart
+++ b/lib/parser/function_parser/conversions_parser.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: annotate_overrides, overridden_fields, prefer_if_elements_to_conditional_expressions
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/function_parser/filtering_projection_parser.dart
+++ b/lib/parser/function_parser/filtering_projection_parser.dart
@@ -2,11 +2,11 @@
 
 // Package imports:
 import 'package:collection/collection.dart';
-import 'package:fhir_dstu2/fhir_dstu2.dart' as dstu2;
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart' as r4;
-import 'package:fhir_r5/fhir_r5.dart' as r5;
-import 'package:fhir_stu3/fhir_stu3.dart' as stu3;
+import 'package:fhir/dstu2.dart' as dstu2;
+import 'package:fhir/primitive_types/primitive_types.dart';
+import 'package:fhir/r4.dart' as r4;
+import 'package:fhir/r5.dart' as r5;
+import 'package:fhir/stu3.dart' as stu3;
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/function_parser/utility_parser.dart
+++ b/lib/parser/function_parser/utility_parser.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: annotate_overrides, overridden_fields, avoid_dynamic_calls
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 
 // Project imports:
 import '../../fhir_path.dart';

--- a/lib/parser/literal_parser.dart
+++ b/lib/parser/literal_parser.dart
@@ -1,11 +1,11 @@
 // ignore_for_file: annotate_overrides, overridden_fields, avoid_dynamic_calls, avoid_bool_literals_in_conditional_expressions
 
 import 'package:collection/collection.dart';
-import 'package:fhir_dstu2/fhir_dstu2.dart' as dstu2;
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart' as r4;
-import 'package:fhir_r5/fhir_r5.dart' as r5;
-import 'package:fhir_stu3/fhir_stu3.dart' as stu3;
+import 'package:fhir/dstu2.dart' as dstu2;
+import 'package:fhir/primitive_types/primitive_types.dart';
+import 'package:fhir/r4.dart' as r4;
+import 'package:fhir/r5.dart' as r5;
+import 'package:fhir/stu3.dart' as stu3;
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/operation_parser/comparison_parser.dart
+++ b/lib/parser/operation_parser/comparison_parser.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: annotate_overrides, overridden_fields, avoid_dynamic_calls, avoid_bool_literals_in_conditional_expressions
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/operation_parser/equality_parser.dart
+++ b/lib/parser/operation_parser/equality_parser.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: annotate_overrides, overridden_fields, noop_primitive_operations, unnecessary_this
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/operation_parser/math_parser.dart
+++ b/lib/parser/operation_parser/math_parser.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: annotate_overrides, overridden_fields, avoid_dynamic_calls
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/parser/operation_parser/types_parser.dart
+++ b/lib/parser/operation_parser/types_parser.dart
@@ -1,11 +1,11 @@
 // ignore_for_file: annotate_overrides, overridden_fields, avoid_dynamic_calls
 
 // Package imports:
-import 'package:fhir_dstu2/fhir_dstu2.dart' as dstu2;
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart' as r4;
-import 'package:fhir_r5/fhir_r5.dart' as r5;
-import 'package:fhir_stu3/fhir_stu3.dart' as stu3;
+import 'package:fhir/dstu2.dart' as dstu2;
+import 'package:fhir/primitive_types/primitive_types.dart';
+import 'package:fhir/r4.dart' as r4;
+import 'package:fhir/r5.dart' as r5;
+import 'package:fhir/stu3.dart' as stu3;
 import 'package:ucum/ucum.dart';
 
 // Project imports:

--- a/lib/walk_fhir_path.dart
+++ b/lib/walk_fhir_path.dart
@@ -1,8 +1,8 @@
 // Package imports:
-import 'package:fhir_dstu2/fhir_dstu2.dart' as dstu2;
-import 'package:fhir_r4/fhir_r4.dart' as r4;
-import 'package:fhir_r5/fhir_r5.dart' as r5;
-import 'package:fhir_stu3/fhir_stu3.dart' as stu3;
+import 'package:fhir/dstu2.dart' as dstu2;
+import 'package:fhir/r4.dart' as r4;
+import 'package:fhir/r5.dart' as r5;
+import 'package:fhir/stu3.dart' as stu3;
 import 'package:petitparser/core.dart';
 
 // Project imports:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,24 +2,14 @@ name: fhir_path
 description: FHIRPath navigation and extraction language implemented in pure Dart to be used with base FHIR packages.
 version: 0.11.3
 homepage: https://www.fhirfli.dev/
-repository: https://github.com/MayJuun/fhir/tree/main/fhir_path
+repository: https://github.com/fhir-fli/fhir_path
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
   collection: ^1.18.0
-  fhir_dstu2:
-    path: ../fhir_dstu2
-  fhir_primitives: ^0.1.0
-  fhir_r4:
-    path: ../fhir_r4
-  fhir_r5:
-    path: ../fhir_r5
-  fhir_r6:
-    path: ../fhir_r6
-  fhir_stu3:
-    path: ../fhir_stu3
+  fhir: ^0.12.0
   ucum: ^0.4.0
   petitparser: ^6.0.2
 

--- a/test/lib/fhir_path_test/test_arg_fxns.dart
+++ b/test/lib/fhir_path_test/test_arg_fxns.dart
@@ -4,8 +4,7 @@
 import 'dart:convert';
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 
 // Project imports:
@@ -1160,13 +1159,13 @@ final resource = Patient(
 
 final bundle = Bundle(
   entry: [
-    BundleEntry(resource: Patient(id: '1')),
-    BundleEntry(resource: Practitioner(id: '2')),
-    BundleEntry(resource: Patient(id: '3')),
-    BundleEntry(resource: Practitioner(id: '4')),
-    BundleEntry(resource: Practitioner(id: '5')),
-    BundleEntry(resource: Patient(id: '6')),
-    BundleEntry(resource: Patient(id: '7')),
+    BundleEntry(resource: Patient(fhirId: '1')),
+    BundleEntry(resource: Practitioner(fhirId: '2')),
+    BundleEntry(resource: Patient(fhirId: '3')),
+    BundleEntry(resource: Practitioner(fhirId: '4')),
+    BundleEntry(resource: Practitioner(fhirId: '5')),
+    BundleEntry(resource: Patient(fhirId: '6')),
+    BundleEntry(resource: Patient(fhirId: '7')),
   ],
 );
 

--- a/test/lib/fhir_path_test/test_basic_operators.dart
+++ b/test/lib/fhir_path_test/test_basic_operators.dart
@@ -1,8 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, unnecessary_statements, leading_newlines_in_multiline_strings, directives_ordering, always_specify_types
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 
 // Project imports:

--- a/test/lib/fhir_path_test/test_basic_types.dart
+++ b/test/lib/fhir_path_test/test_basic_types.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, unnecessary_statements, leading_newlines_in_multiline_strings, directives_ordering, always_specify_types, unnecessary_parenthesis, avoid_dynamic_calls, unnecessary_string_escapes
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
+import 'package:fhir/primitive_types/primitive_types.dart';
 import 'package:test/test.dart';
 
 // Project imports:

--- a/test/lib/fhir_path_test/test_date_times.dart
+++ b/test/lib/fhir_path_test/test_date_times.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, avoid_escaping_inner_quotes, always_specify_types
 
 // Package imports:
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 
 // Project imports:

--- a/test/lib/fhir_path_test/test_no_arg_fxns.dart
+++ b/test/lib/fhir_path_test/test_no_arg_fxns.dart
@@ -1,8 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, always_specify_types, unnecessary_string_escapes
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 import 'package:ucum/ucum.dart';
 
@@ -1327,8 +1326,8 @@ void testNoArgFxns() {
       final endTimeOfDay = FhirTime(
           DateTime.now().toIso8601String().split('T').last.substring(0, 12));
       expect(
-          (startTimeOfDay <= (resultTimeOfDay as FhirTime) ?? false) &&
-              (endTimeOfDay >= resultTimeOfDay ?? false),
+          (startTimeOfDay <= (resultTimeOfDay as FhirTime)) &&
+              (endTimeOfDay >= resultTimeOfDay),
           true);
       expect(
           walkFhirPath(context: resource.toJson(), pathExpression: "today()")

--- a/test/lib/fhir_path_test/test_paths.dart
+++ b/test/lib/fhir_path_test/test_paths.dart
@@ -1,8 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, no_adjacent_strings_in_list, avoid_escaping_inner_quotes, always_specify_types
 
 // Package imports:
-import 'package:fhir_primitives/fhir_primitives.dart';
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 
 // Project imports:

--- a/test/lib/fhir_path_test/test_questionnaire.dart
+++ b/test/lib/fhir_path_test/test_questionnaire.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages, prefer_single_quotes, avoid_escaping_inner_quotes, always_specify_types
 
 // Package imports:
-import 'package:fhir_r4/fhir_r4.dart';
+import 'package:fhir/r4.dart';
 import 'package:test/test.dart';
 
 // Project imports:

--- a/test/pubspec.yaml
+++ b/test/pubspec.yaml
@@ -6,8 +6,10 @@ environment:
 
 dependencies:
   fhir_primitives: ^0.1.0
-  fhir_r4:
-    path: ../../fhir_r4
+  fhir: ^0.12.0
+  fhir_path:
+    path:
+      ../.
   flutter:
     sdk: flutter
   ucum: ^0.4.0


### PR DESCRIPTION
This PR updates the package to point to `fhir` version `0.12.0` and also contains a few outdated references that seem to stem from the old monorepo location.